### PR TITLE
Use only https protocol for artifact repos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -295,7 +295,7 @@
         <repository>
             <id>jcenter</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
         </repository>
         <repository>
             <id>kategory</id>


### PR DESCRIPTION
Ta zmiana naprawia poniższy błąd.

Próba pobrania zależności projektu z repo maven generuje błąd.

> [ERROR] Failed to execute goal on project kotlin: Could not resolve dependencies for project jug.workshops:kotlin:jar:1.0-SNAPSHOT: Failed to collect dependencies at io.ktor:ktor-server-core:jar:1.1.1 -> org.jetbrains.kotlinx:atomicfu:jar:0.12.0: Failed to read artifact descriptor for org.jetbrains.kotlinx:atomicfu:jar:0.12.0: Could not transfer artifact org.jetbrains.kotlinx:atomicfu:pom:0.12.0 from/to jcenter (http://jcenter.bintray.com): Authorization failed for http://jcenter.bintray.com/org/jetbrains/kotlinx/atomicfu/0.12.0/atomicfu-0.12.0.pom 403 Forbidden -> [Help 1]

Przy próbie wejścia na repo jcenter jest komunikat, że dostęp jest możliwy wyłącznie przez https.